### PR TITLE
upgrades TLS to version 1.1 and 1.2, which fixes the PrimaryAuth sample

### DIFF
--- a/primary-auth/okta-aspnet-mvc-example/Startup.cs
+++ b/primary-auth/okta-aspnet-mvc-example/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Owin;
+﻿using System.Net;
+using Microsoft.Owin;
 using Owin;
 
 [assembly: OwinStartup(typeof(okta_aspnet_mvc_example.Startup))]
@@ -12,6 +13,8 @@ namespace okta_aspnet_mvc_example
         public void Configuration(IAppBuilder app)
         {
             ConfigureAuth(app);
+
+            System.Net.ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
         }
     }
 }


### PR DESCRIPTION
Fixes `An existing connection was forcibly closed by the remote host` in the PrimaryAuth sample, caused by TLS version mismatch by default (on some versions of .net framework)