### PR TITLE
Updated the sample Okta-hosted-login for dotnet48 Okta OIDC - the previous solution is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,15 @@ Please find the sample that fits your use-case from the table below.
 ## Contributing
  
 We're happy to accept contributions and PRs! Please see the [contribution guide](CONTRIBUTING.md) to understand how to structure a contribution.
+
+ 
+## Okta-Hosted-Login with dotnet48 MVC webapp and Okta OIDC
+This webapp is able to authenticate with Okta and fetch back the user claims and id_token payload in the Owin context. However, the below issues are present and will not be readily resolved (MSFT Owin framework issue). Therefore, we would **not** recommend using dotnet48 with Okta OIDC. Instead, please upgrade to dotnet core to use Okta OIDC or if that is not possible, use dotnet48 with Okta SAML.
+ 
+## Known Issues
+1. The Owin context does not contain the access token. It is null at runtime. This is a known issue with the Owin framework and is not resolved by Microsoft. Therefore, the access token cannot be fetched from the Owin context. If you need to call external APIs, this will be an issue. The proposed solution here is to create an OktaAdapter that will fetch and validate the access token.
+2. Global signout does not work. This app's signout will result in a redirect to the global Okta org's configured error page. Instead, you may need to try Okta's Single Logout URL (see link below) or manually clearing the cookies, Okta session, and local session. If using JWT to manage user session, configure a low expiry access token and long refresh token approach.
+3. Okta's prescribed solution with app.UseOktaMvc in Startup.cs does not work. It will result in an infinite redirect loop between the webapp and Okta's AuthZ server due to a thrown error. This looks to be an issue with Okta's aspnet library and dotnet48 Owin's middleware. Instead, I modified the service to instead call app.UseOpenIdConnectAuthentication directly - which works. I believe the user claims are pulled from the user-info endpoint though and not the id_token.
+
+## References
+- [Okta Single Logout](https://help.okta.com/en-us/content/topics/apps/apps_single_logout.htm)

--- a/okta-hosted-login/okta-aspnet-mvc-example/Controllers/HomeController.cs
+++ b/okta-hosted-login/okta-aspnet-mvc-example/Controllers/HomeController.cs
@@ -28,7 +28,18 @@ namespace okta_aspnet_mvc_example.Controllers
         [Authorize]
         public ActionResult Profile()
         {
-            return View(HttpContext.GetOwinContext().Authentication.User.Claims);
+            var user = HttpContext.GetOwinContext().Authentication.User;
+            var claims = user.Claims;
+            var accessToken = user.Claims.FirstOrDefault(c => c.Type == "access_token")?.Value;
+            var idToken = user.Claims.FirstOrDefault(c => c.Type == "id_token")?.Value;
+            Console.WriteLine("This is accessToken: " + accessToken); // this will be null
+            Console.WriteLine("This is idToken: " + idToken); // this will be null
+
+            ViewBag.AccessToken = accessToken;
+            ViewBag.IdToken = idToken;
+
+            return View(claims);
         }
+
     }
 }

--- a/okta-hosted-login/okta-aspnet-mvc-example/Startup.cs
+++ b/okta-hosted-login/okta-aspnet-mvc-example/Startup.cs
@@ -1,23 +1,49 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Configuration;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using System.Web.Services.Description;
+using Antlr.Runtime;
+using IdentityModel.Client;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.Owin;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
+using Microsoft.Owin.Security.OpenIdConnect;
 using Okta.AspNet;
 using Owin;
+using static IdentityModel.OidcConstants;
 
-[assembly: OwinStartup(typeof(okta_aspnet_mvc_example.Startup))]
+[assembly: OwinStartup(typeof(dotnet48_okta_oidc_webapp.Startup))]
 
-namespace okta_aspnet_mvc_example
+namespace dotnet48_okta_oidc_webapp
 {
     public class Startup
     {
         public void Configuration(IAppBuilder app)
         {
+            // Enable TLS 1.2
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+
+            /*
             app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
-
-            app.UseCookieAuthentication(new CookieAuthenticationOptions());
-
+ 
+            //app.UseCookieAuthentication(new CookieAuthenticationOptions()
+            //{
+            //    LoginPath = new PathString("/Account/Login"),
+            //});
+ 
+            app.UseCookieAuthentication(new Microsoft.Owin.Security.Cookies.CookieAuthenticationOptions
+            {
+                AuthenticationType = "ApplicationCookie",
+                LoginPath = new PathString("/Account/Login")
+            });
+ 
             app.UseOktaMvc(new OktaMvcOptions()
             {
                 OktaDomain = ConfigurationManager.AppSettings["okta:OktaDomain"],
@@ -26,9 +52,97 @@ namespace okta_aspnet_mvc_example
                 AuthorizationServerId = ConfigurationManager.AppSettings["okta:AuthorizationServerId"],
                 RedirectUri = ConfigurationManager.AppSettings["okta:RedirectUri"],
                 PostLogoutRedirectUri = ConfigurationManager.AppSettings["okta:PostLogoutRedirectUri"],
-                GetClaimsFromUserInfoEndpoint = true,
-                Scope = new List<string> {"openid", "profile", "email"},
+                Scope = new List<string> { "openid", "profile", "email" },
+                //LoginMode = LoginMode.SelfHosted,
             });
+            */
+            ConfigureAuth(app);
+
+
         }
+        private void ConfigureAuth(IAppBuilder app)
+        {
+            app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
+
+            app.UseCookieAuthentication(new CookieAuthenticationOptions
+            {
+                AuthenticationType = CookieAuthenticationDefaults.AuthenticationType,
+            });
+
+            var clientId = ConfigurationManager.AppSettings["okta:ClientId"].ToString();
+            var clientSecret = ConfigurationManager.AppSettings["okta:ClientSecret"].ToString();
+            var issuer = ConfigurationManager.AppSettings["okta:Issuer"].ToString();
+            var redirectUri = ConfigurationManager.AppSettings["okta:RedirectUri"].ToString();
+            var postLogoutRedirectUri = ConfigurationManager.AppSettings["okta:PostLogoutRedirectUri"].ToString();
+            UserInfoResponse userInfoResponse;
+
+            app.UseOpenIdConnectAuthentication(new OpenIdConnectAuthenticationOptions
+            {
+                ClientId = clientId,
+                ClientSecret = clientSecret,
+                Authority = issuer,
+                RedirectUri = redirectUri,
+                ResponseType = "id_token token",
+                UseTokenLifetime = false,
+                Scope = "openid profile email",
+                PostLogoutRedirectUri = postLogoutRedirectUri,
+                TokenValidationParameters = new TokenValidationParameters
+                {
+                    NameClaimType = "name"
+                },
+                Notifications = new OpenIdConnectAuthenticationNotifications
+                {
+                    RedirectToIdentityProvider = context =>
+                    {
+                        if (context.ProtocolMessage.RequestType == OpenIdConnectRequestType.Logout)
+                        {
+                            var idToken = context.OwinContext.Authentication.User.Claims.FirstOrDefault(c => c.Type == "id_token")?.Value;
+                            context.ProtocolMessage.IdTokenHint = idToken;
+                        }
+
+                        return Task.FromResult(true);
+                    },
+                    AuthorizationCodeReceived = async context =>
+                    {
+                        // Exchange code for access and ID tokens
+                        var tokenClient = new TokenClient(
+                            issuer + "/v1/token", clientId, clientSecret);
+                        var tokenResponse = await tokenClient.RequestAuthorizationCodeAsync(context.ProtocolMessage.Code, redirectUri);
+
+                        if (tokenResponse.IsError)
+                        {
+                            throw new Exception(tokenResponse.Error);
+                        }
+
+                        var userInfoClient = new UserInfoClient(issuer + "/v1/userinfo");
+                        userInfoResponse = await userInfoClient.GetAsync(tokenResponse.AccessToken);
+
+                        var identity = new ClaimsIdentity();
+                        identity.AddClaims(userInfoResponse.Claims);
+                        identity.AddClaim(new Claim("id_token", tokenResponse.IdentityToken));
+                        identity.AddClaim(new Claim("access_token", tokenResponse.AccessToken));
+                        if (!string.IsNullOrEmpty(tokenResponse.RefreshToken))
+                        {
+                            identity.AddClaim(new Claim("refresh_token", tokenResponse.RefreshToken));
+                        }
+
+                        var nameClaim = new Claim(ClaimTypes.Name, userInfoResponse.Claims.FirstOrDefault(c => c.Type == "name")?.Value);
+                        identity.AddClaim(nameClaim);
+
+
+                        context.AuthenticationTicket = new AuthenticationTicket(
+                            new ClaimsIdentity(identity.Claims, context.AuthenticationTicket.Identity.AuthenticationType),
+                            context.AuthenticationTicket.Properties);
+
+                        Console.WriteLine("This is tokenResponse.AccessToken: ");
+                        Console.WriteLine(tokenResponse.AccessToken);
+                        Trace.WriteLine("This is tokenResponse.AccessToken: ");
+                        Trace.WriteLine(tokenResponse.AccessToken);
+                    }
+                }
+            });
+            Console.WriteLine("Okta OpenID Connect middleware registered.");
+        }
+
     }
 }

--- a/okta-hosted-login/okta-aspnet-mvc-example/Views/Home/Profile.cshtml
+++ b/okta-hosted-login/okta-aspnet-mvc-example/Views/Home/Profile.cshtml
@@ -6,7 +6,9 @@
 
 <h2>@ViewBag.Title</h2>
 
-<dl class="dl-horizontal">
+@if (Context.User.Identity.IsAuthenticated)
+{
+    <dl class="dl-horizontal">
     @foreach (var claim in Model)
     {
         <dt title="@claim.Type">
@@ -22,4 +24,9 @@
 
         <dd id="@String.Format("claim-{0}", claim.Type)">@claim.Value</dd>
     }
-</dl>
+    </dl>
+} else {
+    <ul class="nav navbar-nav navbar-right">
+    <li>@Html.ActionLink("Log in", "Login", "Account")</li>
+    </ul>
+}

--- a/okta-hosted-login/okta-aspnet-mvc-example/Views/Shared/_Layout.cshtml
+++ b/okta-hosted-login/okta-aspnet-mvc-example/Views/Shared/_Layout.cshtml
@@ -1,5 +1,6 @@
 ﻿<!DOCTYPE html>
 <html>
+
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,6 +8,7 @@
     @Styles.Render("~/Content/css")
     @Scripts.Render("~/bundles/modernizr")
 </head>
+
 <body>
     <div class="navbar navbar-inverse navbar-fixed-top">
         <div class="container">
@@ -16,31 +18,36 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                @Html.ActionLink("Okta Sample App", "Index", "Home", new { area = "" }, new { @class = "navbar-brand" })
+                @Html.ActionLink("Application name", "Index", "Home", new { area = "" }, new
+                    {
+                        @class = "navbar-brand"
+                    })
             </div>
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
+                    <li>@Html.ActionLink("Launches", "Index", "Launch")</li>
                     <li>@Html.ActionLink("Home", "Index", "Home")</li>
                     <li>@Html.ActionLink("About", "About", "Home")</li>
+                    <li>@Html.ActionLink("Profile", "Profile", "Home")</li>
                     <li>@Html.ActionLink("Contact", "Contact", "Home")</li>
                 </ul>
                 @if (Context.User.Identity.IsAuthenticated)
-                    {
-                <ul class="nav navbar-nav navbar-right">
-                    <li>
-                        <p class="navbar-text">Hello, <b>@Context.User.Identity.Name</b></p>
-                    </li>
-                    <li>@Html.ActionLink("Profile", "Profile", "Home", null, new {id = "profile-button" })</li>
-                    <li>
-                        <a id="logout-button" onclick="document.getElementById('logout_form').submit();" style="cursor: pointer;">Log out</a>
-                    </li>
-                </ul>
-                <form action="/Account/Logout" method="post" id="logout_form"></form>
+                {
+                    <ul class="nav navbar-nav navbar-right">
+                        <li>
+                            <p class="navbar-text">Hello, <b>@Context.User.Identity.Name</b></p>
+                        </li>
+                        <li>
+                            <a onclick="document.getElementById('logout_form').submit();" style="cursor: pointer;">Log
+                                out</a>
+                        </li>
+                    </ul>
+                    <form action="/Account/Logout" method="post" id="logout_form"></form>
                 }
                 else
                 {
                     <ul class="nav navbar-nav navbar-right">
-                        <li>@Html.ActionLink("Log in", "Login", "Account", null, new {id = "login-button" })</li>
+                        <li>@Html.ActionLink("Log in", "Login", "Account")</li>
                     </ul>
                 }
             </div>
@@ -58,4 +65,5 @@
     @Scripts.Render("~/bundles/bootstrap")
     @RenderSection("scripts", required: false)
 </body>
+
 </html>

--- a/okta-hosted-login/okta-aspnet-mvc-example/Views/Shared/_Layout.cshtml
+++ b/okta-hosted-login/okta-aspnet-mvc-example/Views/Shared/_Layout.cshtml
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <meta charset="utf-8" />
@@ -18,14 +18,10 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                @Html.ActionLink("Application name", "Index", "Home", new { area = "" }, new
-                    {
-                        @class = "navbar-brand"
-                    })
+                @Html.ActionLink("Okta Sample App", "Index", "Home", new { area = "" }, new { @class = "navbar-brand" })
             </div>
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
-                    <li>@Html.ActionLink("Launches", "Index", "Launch")</li>
                     <li>@Html.ActionLink("Home", "Index", "Home")</li>
                     <li>@Html.ActionLink("About", "About", "Home")</li>
                     <li>@Html.ActionLink("Profile", "Profile", "Home")</li>

--- a/okta-hosted-login/okta-aspnet-mvc-example/Web.config
+++ b/okta-hosted-login/okta-aspnet-mvc-example/Web.config
@@ -1,98 +1,125 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
-  https://go.microsoft.com/fwlink/?LinkId=301880
+https://go.microsoft.com/fwlink/?LinkId=301880
   -->
 <configuration>
-  <appSettings>
-    <add key="webpages:Version" value="3.0.0.0" />
-    <add key="webpages:Enabled" value="false" />
-    <add key="ClientValidationEnabled" value="true" />
-    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+<configSections>
+<!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+<section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+</configSections>
+<appSettings>
+<add key="webpages:Version" value="3.0.0.0"/>
+<add key="webpages:Enabled" value="false"/>
+<add key="ClientValidationEnabled" value="true"/>
+<add key="UnobtrusiveJavaScriptEnabled" value="true"/>
+<add key="okta:ClientId" value=""/>
+<add key="okta:ClientSecret" value=""/>
+<add key="okta:AuthorizationServerId" value=""/>
+<add key="okta:Audience" value=""/>
+<add key="okta:Issuer" value=""/>
+<add key="okta:OktaDomain" value=""/>
+<add key="okta:LogoutUri" value="https://localhost:8080/signout/callback"/>
+<add key="okta:RedirectUri" value="https://localhost:8080/authorization-code/callback"/>
+<add key="okta:PostLogoutRedirectUri" value="https://localhost:8080/account/postlogout"/>
+</appSettings>
+<!--
+    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 
-    <!-- 1. Replace these values with your Okta configuration -->
-    <add key="okta:ClientId" value="{ClientId}" />
-    <add key="okta:ClientSecret" value="{ClientSecret}" />
-    <add key="okta:OktaDomain" value="https://{yourOktaDomain}" />
-    <add key="okta:AuthorizationServerId" value="default" />
-
-    <!-- 2. Update the Okta application with these values -->
-    <add key="okta:RedirectUri" value="https://localhost:44314/authorization-code/callback" />
-    <add key="okta:PostLogoutRedirectUri" value="https://localhost:44314/Account/PostLogout" />
-    
-  </appSettings>
-  <system.web>
-    <compilation debug="true" targetFramework="4.8" />
-    <httpRuntime targetFramework="4.8" />
-  </system.web>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" />
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.17.0.0" newVersion="6.17.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.35.0.0" newVersion="6.35.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
-  <system.codedom>
-    <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
-    </compilers>
-  </system.codedom>
+    The following attributes can be set on the <httpRuntime> tag.
+<system.Web>
+<httpRuntime targetFramework="4.8" />
+</system.Web>
+  -->
+<system.web>
+<authentication mode="None" />
+<compilation debug="true" targetFramework="4.8" />
+<httpRuntime targetFramework="4.8" />
+</system.web>
+<runtime>
+<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+<dependentAssembly>
+<assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f"/>
+<bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
+</dependentAssembly>
+<dependentAssembly>
+<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed"/>
+<bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
+</dependentAssembly>
+<dependentAssembly>
+<assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35"/>
+<bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
+</dependentAssembly>
+<dependentAssembly>
+<assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35"/>
+<bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930"/>
+</dependentAssembly>
+<dependentAssembly>
+<assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
+<bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+</dependentAssembly>
+<dependentAssembly>
+<assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
+<bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+</dependentAssembly>
+<dependentAssembly>
+<assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
+<bindingRedirect oldVersion="1.0.0.0-5.2.4.0" newVersion="5.2.4.0"/>
+</dependentAssembly>
+<dependentAssembly>
+<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+<bindingRedirect oldVersion="0.0.0.0-5.4.0.0" newVersion="5.4.0.0"/>
+</dependentAssembly>
+<dependentAssembly>
+<assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+<bindingRedirect oldVersion="0.0.0.0-5.4.0.0" newVersion="5.4.0.0"/>
+</dependentAssembly>
+<dependentAssembly>
+<assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+<bindingRedirect oldVersion="0.0.0.0-5.4.0.0" newVersion="5.4.0.0"/>
+</dependentAssembly>
+<dependentAssembly>
+<assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+<bindingRedirect oldVersion="0.0.0.0-5.2.1.0" newVersion="5.2.1.0"/>
+</dependentAssembly>
+<dependentAssembly>
+<assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+<bindingRedirect oldVersion="0.0.0.0-5.2.1.0" newVersion="5.2.1.0"/>
+</dependentAssembly>
+<dependentAssembly>
+<assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+</dependentAssembly>
+<dependentAssembly>
+<assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+</dependentAssembly>
+</assemblyBinding>
+</runtime>
+<system.codedom>
+<compilers>
+<compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701"/>
+<compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"/>
+</compilers>
+</system.codedom>
+<entityFramework>
+<defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+<parameters>
+<parameter value="mssqllocaldb"/>
+</parameters>
+</defaultConnectionFactory>
+<providers>
+<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
+</providers>
+</entityFramework>
+<connectionStrings>
+<add name="LaunchContext" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=RocketLaunch1;Integrated Security=SSPI;" providerName="System.Data.SqlClient"/>
+</connectionStrings>
+<system.diagnostics>
+<trace autoflush="true" indentsize="4">
+<listeners>
+<add name="myListener" type="System.Diagnostics.TextWriterTraceListener" initializeData="" />
+</listeners>
+</trace>
+</system.diagnostics>
 </configuration>


### PR DESCRIPTION
You can modify the PR changes, README as needed. The existing solution with app.UseOktaMvc in Startup.cs does not work - for *dotnet48 and Okta OIDC. It will result in an infinite redirect loop between the webapp and Okta's AuthZ server due to a thrown error. This looks to be an issue with Okta's aspnet library and dotnet48 Owin's middleware. Instead, I modified the service to instead call app.UseOpenIdConnectAuthentication directly - which works. I believe the user claims are pulled from the user-info endpoint though and not the id_token. I was unable to get Single Logout to work, but I have not personally experimented with the solutions in item 2 below. 

---
From README commit.

## Okta-Hosted-Login with dotnet48 MVC webapp and Okta OIDC
This webapp is able to authenticate with Okta and fetch back the user claims and id_token payload in the Owin context. However, the below issues are present and will not be readily resolved (MSFT Owin framework issue). Therefore, we would **not** recommend using dotnet48 with Okta OIDC. Instead, please upgrade to dotnet core to use Okta OIDC or if that is not possible, use dotnet48 with Okta SAML.
 
## Known Issues
1. The Owin context does not contain the access token. It is null at runtime. This is a known issue with the Owin framework and is not resolved by Microsoft. Therefore, the access token cannot be fetched from the Owin context. If you need to call external APIs, this will be an issue. The proposed solution here is to create an OktaAdapter that will fetch and validate the access token.
2. Global signout does not work. This app's signout will result in a redirect to the global Okta org's configured error page. Instead, you may need to try Okta's Single Logout URL (see link below) or manually clearing the cookies, Okta session, and local session. If using JWT to manage user session, configure a low expiry access token and long refresh token approach.
3. Okta's prescribed solution with app.UseOktaMvc in Startup.cs does not work. It will result in an infinite redirect loop between the webapp and Okta's AuthZ server due to a thrown error. This looks to be an issue with Okta's aspnet library and dotnet48 Owin's middleware. Instead, I modified the service to instead call app.UseOpenIdConnectAuthentication directly - which works. I believe the user claims are pulled from the user-info endpoint though and not the id_token.