### PR TITLE
OKTA-789927: Move away from orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,13 @@
 version: 2.1
 
 orbs:
-  general-platform-helpers: okta/general-platform-helpers@1.8
+  general-platform-helpers: okta/general-platform-helpers@1.9
 
 workflows:
   # See OKTA-624620
   semgrep:
     jobs:
-      - general-platform-helpers/job-semgrep-prepare:
-          name: semgrep-prepare
       - general-platform-helpers/job-semgrep-scan:
           name: "Scan with Semgrep"
-          requires:
-            - semgrep-prepare
+          context:
+            - static-analysis


### PR DESCRIPTION
This moves away from orb-defined jobs when running static analysis tooling.