### PR TITLE
fix: resolved core-js vulnerability by upgrading wait-on package

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -28,7 +28,7 @@
       "jasmine-reporters": "^2.2.0",
       "platform": "^1.3.5",
       "protractor": "^5.1.0",
-      "wait-on": "^2.0.2"
+      "wait-on": "^8.0.1"
     },
     "bin": {},
     "private": true


### PR DESCRIPTION
Upgraded wait-on from version 2.0.2 as the previous version was using core-js which was no longer maintained, which helped to resolve the vulnerability.